### PR TITLE
Upgrade terraform-provider-qovery to v0.37.0

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/pulumi/pulumi-terraform-bridge/pf v0.40.0
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.87.0
 	github.com/pulumi/pulumi/sdk/v3 v3.125.0
-	github.com/qovery/terraform-provider-qovery v0.36.1
+	github.com/qovery/terraform-provider-qovery v0.37.0
 )
 
 require (

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -777,8 +777,8 @@ github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20240520223432-0c0bf0d65f10 h1:
 github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20240520223432-0c0bf0d65f10/go.mod h1:H+8tjs9TjV2w57QFVSMBQacf8k/E1XwLXGCARgViC6A=
 github.com/qovery/qovery-client-go v0.0.0-20240708130510-b92d479def66 h1:i0cqbra+NL3Hdxu97wQEX7OAaXTxrfudOtsENtO60Zo=
 github.com/qovery/qovery-client-go v0.0.0-20240708130510-b92d479def66/go.mod h1:9eHj5a4EtXGIyfbvVL3HVYW9k7Xmiwi00OqHrP4dc10=
-github.com/qovery/terraform-provider-qovery v0.36.1 h1:xqPPPpLqDI/2962LnYZ7uboLQDGK36Al5Gy75zaGThc=
-github.com/qovery/terraform-provider-qovery v0.36.1/go.mod h1:0246IGhQiMAwy4tF0VKgtiFEz7rS7AOxHBtA/ojM6Js=
+github.com/qovery/terraform-provider-qovery v0.37.0 h1:O9093GElc+JxcO4NEtTjlVt+CRrVw9jROUSYRWN97NA=
+github.com/qovery/terraform-provider-qovery v0.37.0/go.mod h1:0246IGhQiMAwy4tF0VKgtiFEz7rS7AOxHBtA/ojM6Js=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=


### PR DESCRIPTION
This PR was generated via `$ upgrade-provider dirien/pulumi-qovery --kind=all --target-bridge-version=latest`.

---

- Upgrading terraform-provider-qovery from 0.36.1  to 0.37.0.
